### PR TITLE
Add user profile view and update endpoints

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -45,3 +45,5 @@ tmp/
 temp/
 
 
+user_test.go
+user_test.go

--- a/backend/main.go
+++ b/backend/main.go
@@ -19,12 +19,15 @@ func main() {
 	public.POST("/login", Login)
 	public.GET("/listings", GetListings)
 	public.GET("/listings/:id", GetListingByID)
+	public.GET("/user/:id", GetUserPublic)
+
 	protected := r.Group("/api/admin")
 	protected.Use(JWTMiddleware())
 	protected.GET("/user", CurrentUser)
 	protected.POST("/listings", CreateListing)
 	protected.PUT("/listings/:id", UpdateListing)
 	protected.DELETE("/listings/:id", DeleteListing)
+	protected.PUT("/user", UpdateUser)
 	err := r.Run(":8080")
 	if err != nil {
 		return

--- a/backend/user.go
+++ b/backend/user.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"html"
 	"strings"
-
+	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -61,4 +61,71 @@ func (u *User) SaveUser() (*User, error) {
 	}
 
 	return u, nil
+}
+
+
+
+func GetUserPublic(c *gin.Context) {
+    id := c.Param("id")
+    var u User
+
+    if err := DB.First(&u, id).Error; err != nil {
+        c.JSON(404, gin.H{"error": "User not found"})
+        return
+    }
+
+    u.Password = "" // make sure password is not returned 
+    c.JSON(200, u)
+}
+
+
+type UpdateUserInput struct {
+    Username string `json:"username"`
+    Password string `json:"password"`
+}
+
+func UpdateUser(c *gin.Context) {
+    uid, err := ExtractTokenID(c)
+    if err != nil {
+        c.JSON(401, gin.H{"error": "Unauthorized"})
+        return
+    }
+
+    var u User
+    if err := DB.First(&u, uid).Error; err != nil {
+        c.JSON(404, gin.H{"error": "User not found"})
+        return
+    }
+
+    var input UpdateUserInput
+    if err := c.ShouldBindJSON(&input); err != nil {
+        c.JSON(400, gin.H{"error": "Invalid JSON"})
+        return
+    }
+
+    // Update username if provided
+    if input.Username != "" {
+        u.Username = html.EscapeString(strings.TrimSpace(input.Username))
+    }
+
+    // Update password if provided
+    if input.Password != "" {
+        hashed, _ := bcrypt.GenerateFromPassword([]byte(input.Password), bcrypt.DefaultCost)
+        u.Password = string(hashed)
+    }
+
+	if err := DB.Save(&u).Error; err != nil {
+		c.JSON(400, gin.H{
+			"error":   "Could not update user",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	u.Password = ""
+
+	c.JSON(200, gin.H{
+		"message": "User updated successfully",
+		"user":    u,
+	})
 }


### PR DESCRIPTION
Summary
- Added GET /api/user/:id to return a public user profile without exposing the password.
- Added PUT /api/admin/user to allow the authenticated user to update their username and/or password.
- Ensured password is never returned in any user response.

Endpoints
- GET /api/user/:id
- PUT /api/admin/user (requires Bearer JWT token)

Testing
- go test ./...
- go test -v
- Manually tested:
  - register → login → GET /api/user/:id
  - PUT /api/admin/user updates username/password successfully
  - duplicate username returns 400 with a clear error