### PR TITLE
Support Multi-Image Uploads for Listings

### DIFF
--- a/backend/image.go
+++ b/backend/image.go
@@ -162,3 +162,16 @@ func processImage(c *gin.Context, file *multipart.FileHeader, folder string) (st
 
 	return dst, uniqueName, file
 }
+
+func processMultipleImages(c *gin.Context, files []*multipart.FileHeader, folder string) ([]string, []string, []*multipart.FileHeader) {
+	var uniqueNames []string
+	var dsts []string
+
+	for _, file := range files {
+		dst, uniqueName, _ := processImage(c, file, folder)
+		uniqueNames = append(uniqueNames, uniqueName)
+		dsts = append(dsts, dst)
+	}
+
+	return dsts, uniqueNames, files
+}

--- a/backend/listings.go
+++ b/backend/listings.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 
@@ -20,7 +21,7 @@ type Listing struct {
 	Condition   string  `json:"condition"`
 	UserID      uint    `json:"user_id"`
 	Status      string  `json:"status" gorm:"default:available"`
-	Image       string  `json:"image"`
+	Image       []byte  `json:"image"`
 }
 
 type ListingResponse struct {
@@ -36,7 +37,7 @@ type UpdateListingInput struct {
 	Category    *string  `json:"category"`
 	Condition   *string  `json:"condition"`
 	Status      *string  `json:"status"`
-	Image       *string  `json:"image"`
+	Image       *[]byte  `json:"image"`
 }
 
 func buildListingResponses(listings []Listing) []ListingResponse {
@@ -113,11 +114,13 @@ func CreateListing(c *gin.Context) {
 	// Assign listing to user
 	input.UserID = userID
 
-	//Process image input
-	file, err := c.FormFile("image")
-	if err == nil {
-		dst, _, _ := processImage(c, file, "listings")
-		input.Image = dst
+	//Process images input
+	form, err := c.MultipartForm()
+	if err == nil && form != nil {
+		if files, ok := form.File["image"]; ok && len(files) > 0 {
+			dsts, _, _ := processMultipleImages(c, files, "listings")
+			input.Image, _ = json.Marshal(dsts)
+		}
 	}
 
 	// Save to DB
@@ -214,16 +217,22 @@ func UpdateListing(c *gin.Context) {
 		return
 	}
 
-	//Process image input
-	file, err := c.FormFile("image")
-	if err == nil {
-		dst, _, _ := processImage(c, file, "listings")
-		input.Image = &dst
+	//Process images input
+	form, err := c.MultipartForm()
+	if err == nil && form != nil {
+		if files, ok := form.File["image"]; ok && len(files) > 0 {
+			dsts, _, _ := processMultipleImages(c, files, "listings")
+			imgBytes, _ := json.Marshal(dsts)
+			input.Image = &imgBytes
+		}
 	}
 
-	old_image_path := listing.Image
-	// Delete old image if it exists
-	os.Remove(old_image_path)
+	var old_image_paths []string
+	_ = json.Unmarshal(listing.Image, &old_image_paths)
+	// Delete old images if they exist
+	for _, old_image_path := range old_image_paths {
+		os.Remove(old_image_path)
+	}
 
 	// Update fields
 	if input.Title != nil {
@@ -246,6 +255,8 @@ func UpdateListing(c *gin.Context) {
 	}
 	if input.Image != nil {
 		listing.Image = *input.Image
+	} else {
+		listing.Image = nil
 	}
 
 	// Save to DB

--- a/backend/main.go
+++ b/backend/main.go
@@ -40,6 +40,7 @@ func main() {
 	}))
 
 	r.Static("/files", "./avatars")
+	r.Static("/listing-files", "./listings")
 
 	// PUBLIC ROUTES
 	r.POST("/api/register", Register)

--- a/backend/user_test.go
+++ b/backend/user_test.go
@@ -659,6 +659,18 @@ func TestListingCategoryRoundTripImage(t *testing.T) {
 	if _, err := io.Copy(createPart, createFile); err != nil {
 		t.Fatal(err)
 	}
+	createFile, err = os.Open("test_imgs/lamp2.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer createFile.Close()
+	createPart, err = createWriter.CreateFormFile("image", "lamp2.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(createPart, createFile); err != nil {
+		t.Fatal(err)
+	}
 	createWriter.Close()
 	reqCreate := httptest.NewRequest("POST", "/api/listings", createBody)
 	reqCreate.Header.Set("Authorization", "Bearer "+token)
@@ -683,8 +695,10 @@ func TestListingCategoryRoundTripImage(t *testing.T) {
 		t.Fatalf("expected created condition Used, got %s", created.Condition)
 	}
 
-	if created.Image == "" {
-		t.Fatalf("expected an image on the created listing, but it has none")
+	var images []string
+	_ = json.Unmarshal(created.Image, &images)
+	if len(images) != 2 {
+		t.Fatalf("expected 2 images on the created listing, got %d", len(images))
 	}
 
 	reqGet := httptest.NewRequest("GET", "/api/listings/1", nil)
@@ -708,8 +722,9 @@ func TestListingCategoryRoundTripImage(t *testing.T) {
 		t.Fatalf("expected fetched condition Used, got %s", fetched.Condition)
 	}
 
-	if fetched.Image == "" {
-		t.Fatalf("expected an image on the fetched listing, but it has none")
+	_ = json.Unmarshal(fetched.Image, &images)
+	if len(images) == 0 {
+		t.Fatalf("expected 2 images on the fetched listing, got %d", len(images))
 	}
 
 	updateBody := &bytes.Buffer{}
@@ -755,8 +770,9 @@ func TestListingCategoryRoundTripImage(t *testing.T) {
 		t.Fatalf("expected updated condition Like new, got %s", updated.Condition)
 	}
 
-	if updated.Image == "" {
-		t.Fatalf("expected an image on the updated listing, but it has none")
+	_ = json.Unmarshal(updated.Image, &images)
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image on the updated listing, got %d", len(images))
 	}
 }
 

--- a/frontend/src/api/listings.ts
+++ b/frontend/src/api/listings.ts
@@ -3,6 +3,7 @@ import type {
   Listing,
   ListingQueryParams,
 } from "@/types/listing";
+import { normalizeListing } from "@/lib/listing-images";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api";
 
@@ -34,17 +35,19 @@ export const isAuthenticated = () => Boolean(getToken());
 
 export const listListings = async (
   // Query params kept for future backend support
-  _params?: ListingQueryParams,
+  params?: ListingQueryParams,
 ): Promise<Listing[]> => {
+  void params;
   const response = await fetch(`${BASE_URL}/listings`);
 
-  return readJson<Listing[]>(response);
+  const listings = await readJson<Listing[]>(response);
+  return listings.map((listing) => normalizeListing(listing, BASE_URL));
 };
 
 export const getListingById = async (id: string): Promise<Listing> => {
   const response = await fetch(`${BASE_URL}/listings/${id}`);
 
-  return readJson<Listing>(response);
+  return normalizeListing(await readJson<Listing>(response), BASE_URL);
 };
 
 export const createListing = async (
@@ -59,7 +62,7 @@ export const createListing = async (
     body: JSON.stringify(data),
   });
 
-  return readJson<Listing>(response);
+  return normalizeListing(await readJson<Listing>(response), BASE_URL);
 };
 
 export const updateListing = async (
@@ -75,7 +78,7 @@ export const updateListing = async (
     body: JSON.stringify(data),
   });
 
-  return readJson<Listing>(response);
+  return normalizeListing(await readJson<Listing>(response), BASE_URL);
 };
 
 export const deleteListing = async (id: number): Promise<void> => {
@@ -102,7 +105,7 @@ export const buyListing = async (id: number): Promise<Listing> => {
     body: JSON.stringify({ status: "sold" }),
   });
 
-  return readJson<Listing>(response);
+  return normalizeListing(await readJson<Listing>(response), BASE_URL);
 };
 
 export const defaultListingSort = "latest" as const;

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -4,16 +4,9 @@ import type {
   UpdateCurrentUserProfileData,
   UserInfo,
 } from "@/types/user";
+import { getApiOrigin, normalizeListing } from "@/lib/listing-images";
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8080/api";
-
-const getApiOrigin = () => {
-  try {
-    return new URL(BASE_URL).origin;
-  } catch {
-    return "http://localhost:8080";
-  }
-};
 
 const normalizeAvatarUrl = (avatar: string) => {
   if (!avatar) {
@@ -24,7 +17,7 @@ const normalizeAvatarUrl = (avatar: string) => {
     return avatar;
   }
 
-  const apiOrigin = getApiOrigin();
+  const apiOrigin = getApiOrigin(BASE_URL);
   const fileName = avatar.split("/").pop();
 
   if (avatar.startsWith("/files/")) {
@@ -111,7 +104,9 @@ export const getCurrentUserListings = async (): Promise<Listing[]> => {
     throw new Error(json.error ?? "Failed to fetch user listings");
   }
 
-  return json.data as Listing[];
+  return (json.data as Listing[]).map((listing) =>
+    normalizeListing(listing, BASE_URL),
+  );
 };
 
 export const updateCurrentUserProfile = async (
@@ -165,7 +160,7 @@ export const uploadCurrentUserAvatar = async (file: File): Promise<string> => {
   }
 
   if (typeof json.filename === "string" && json.filename.length > 0) {
-    return `${getApiOrigin()}/files/${json.filename}`;
+    return `${getApiOrigin(BASE_URL)}/files/${json.filename}`;
   }
 
   throw new Error("Avatar upload succeeded but no URL was returned");

--- a/frontend/src/lib/listing-images.test.ts
+++ b/frontend/src/lib/listing-images.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeListing } from "./listing-images";
+import type { Listing } from "@/types/listing";
+
+const baseListing: Listing = {
+  ID: 1,
+  CreatedAt: "2025-01-01T00:00:00Z",
+  UpdatedAt: "2025-01-01T00:00:00Z",
+  DeletedAt: null,
+  title: "Desk Lamp",
+  description: "Warm light",
+  price: 25,
+  category: "Furniture",
+  condition: "Gently used",
+  user_id: 1,
+  status: "available",
+};
+
+describe("normalizeListing", () => {
+  it("decodes backend base64 JSON image lists into listing file URLs", () => {
+    const image = btoa(JSON.stringify(["listings/lamp.jpg", "listings/lamp2.jpg"]));
+
+    const listing = normalizeListing(
+      {
+        ...baseListing,
+        image,
+      },
+      "http://localhost:8080/api",
+    );
+
+    expect(listing.imageUrls).toEqual([
+      "http://localhost:8080/listing-files/lamp.jpg",
+      "http://localhost:8080/listing-files/lamp2.jpg",
+    ]);
+  });
+
+  it("keeps compatibility with raw JSON image list strings", () => {
+    const listing = normalizeListing(
+      {
+        ...baseListing,
+        image: JSON.stringify(["listings/lamp.jpg"]),
+      },
+      "http://localhost:8080/api",
+    );
+
+    expect(listing.imageUrls).toEqual([
+      "http://localhost:8080/listing-files/lamp.jpg",
+    ]);
+  });
+});

--- a/frontend/src/lib/listing-images.ts
+++ b/frontend/src/lib/listing-images.ts
@@ -1,0 +1,140 @@
+import type { Listing } from "@/types/listing";
+
+export const getApiOrigin = (baseUrl: string) => {
+  try {
+    return new URL(baseUrl).origin;
+  } catch {
+    return "http://localhost:8080";
+  }
+};
+
+const decodeBase64Json = (value: string) => {
+  try {
+    if (typeof window !== "undefined" && typeof window.atob === "function") {
+      return window.atob(value);
+    }
+  } catch {
+    return "";
+  }
+
+  return "";
+};
+
+const parseImageValue = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((image): image is string => typeof image === "string");
+  }
+
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  if (trimmed.startsWith("[") || trimmed.startsWith("\"")) {
+    try {
+      return parseImageValue(JSON.parse(trimmed));
+    } catch {
+      return [trimmed];
+    }
+  }
+
+  const decoded = decodeBase64Json(trimmed);
+  if (decoded) {
+    const decodedImages = parseImageValue(decoded);
+    if (decodedImages.length > 0) {
+      return decodedImages;
+    }
+  }
+
+  return [trimmed];
+};
+
+export const normalizeListingImageUrl = (image: string, apiOrigin: string) => {
+  if (/^https?:\/\//i.test(image) || image.startsWith("data:")) {
+    return image;
+  }
+
+  const normalized = image.replaceAll("\\", "/").replace(/^\.\//, "");
+  const fileName = normalized.split("/").filter(Boolean).pop();
+
+  if (normalized.startsWith("/listing-files/")) {
+    return `${apiOrigin}${normalized}`;
+  }
+
+  if (normalized.startsWith("/files/")) {
+    return `${apiOrigin}${normalized}`;
+  }
+
+  if (normalized.startsWith("listings/") && fileName) {
+    return `${apiOrigin}/listing-files/${fileName}`;
+  }
+
+  return image;
+};
+
+export const normalizeListing = <T extends Listing>(
+  listing: T,
+  baseUrl: string,
+): T => {
+  const apiOrigin = getApiOrigin(baseUrl);
+  const imageUrls = parseImageValue(listing.image).map((image) =>
+    normalizeListingImageUrl(image, apiOrigin),
+  );
+
+  return {
+    ...listing,
+    imageUrls,
+  };
+};
+
+export const getListingPrimaryImage = (listing: Listing) =>
+  listing.imageUrls?.[0] ?? null;
+
+export const getListingPlaceholderImage = (title: string, price: number) => {
+  const palette = [
+    ["#0f4c81", "#4f83ff"],
+    ["#c65d00", "#ffb347"],
+    ["#12664f", "#52b788"],
+    ["#5a189a", "#9d4edd"],
+  ];
+  const seed = title
+    .split("")
+    .reduce((total, character) => total + character.charCodeAt(0), 0);
+  const [startColor, endColor] = palette[seed % palette.length];
+  const initials =
+    title
+      .split(" ")
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((word) => word[0]?.toUpperCase() ?? "")
+      .join("") || "SS";
+  const safeTitle = title.slice(0, 28);
+
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400">
+      <defs>
+        <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0%" stop-color="${startColor}" />
+          <stop offset="100%" stop-color="${endColor}" />
+        </linearGradient>
+      </defs>
+      <rect width="640" height="400" rx="36" fill="url(#g)" />
+      <circle cx="540" cy="86" r="86" fill="rgba(255,255,255,0.14)" />
+      <circle cx="126" cy="338" r="112" fill="rgba(255,255,255,0.1)" />
+      <text x="68" y="168" fill="white" font-family="Arial, sans-serif" font-size="88" font-weight="700">${initials}</text>
+      <text x="68" y="248" fill="rgba(255,255,255,0.92)" font-family="Arial, sans-serif" font-size="34" font-weight="600">${safeTitle}</text>
+      <text x="68" y="302" fill="rgba(255,255,255,0.78)" font-family="Arial, sans-serif" font-size="24">SwampSwap Listing</text>
+      <text x="68" y="352" fill="white" font-family="Arial, sans-serif" font-size="28" font-weight="700">$${price}</text>
+    </svg>
+  `;
+
+  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
+};
+
+export const getListingImageSrc = (listing: Listing) =>
+  getListingPrimaryImage(listing) ??
+  getListingPlaceholderImage(listing.title, listing.price);

--- a/frontend/src/pages/ListingDetail/index.tsx
+++ b/frontend/src/pages/ListingDetail/index.tsx
@@ -12,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { getListingImageSrc, getListingPrimaryImage } from "@/lib/listing-images";
 import { toast } from "sonner";
 import type { Listing } from "@/types/listing";
 
@@ -104,6 +105,7 @@ function ListingDetailPage() {
   const sellerName = listing.seller_name || `User #${listing.user_id}`;
   const sellerInitial = sellerName.trim().charAt(0).toUpperCase() || "U";
   const isOwnListing = currentUser?.id === listing.user_id;
+  const primaryImage = getListingPrimaryImage(listing);
 
   const handleBuy = async () => {
     if (!isAuthenticated()) {
@@ -169,6 +171,32 @@ function ListingDetailPage() {
               <div className="text-4xl font-semibold text-primary">{formattedPrice}</div>
             </CardHeader>
             <CardContent className="space-y-6">
+              <section className="space-y-3">
+                <div className="overflow-hidden rounded-2xl border border-primary/10 bg-muted/50">
+                  <img
+                    src={getListingImageSrc(listing)}
+                    alt={listing.title}
+                    className="h-80 w-full object-cover"
+                  />
+                </div>
+                {listing.imageUrls && listing.imageUrls.length > 1 && (
+                  <div className="grid grid-cols-4 gap-3">
+                    {listing.imageUrls.slice(0, 4).map((imageUrl, index) => (
+                      <img
+                        key={imageUrl}
+                        src={imageUrl}
+                        alt={`${listing.title} ${index + 1}`}
+                        className={`h-20 w-full rounded-lg border object-cover ${
+                          imageUrl === primaryImage
+                            ? "border-primary"
+                            : "border-primary/10"
+                        }`}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+
               <section className="space-y-2">
                 <h2 className="text-lg font-semibold">About this item</h2>
                 <p className="leading-7 text-muted-foreground">{listing.description}</p>

--- a/frontend/src/pages/Listings/index.tsx
+++ b/frontend/src/pages/Listings/index.tsx
@@ -38,6 +38,7 @@ import {
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { getListingImageSrc } from "@/lib/listing-images";
 import { toast } from "sonner";
 import { listingCategories, listingConditions } from "@/types/listing";
 import type {
@@ -81,46 +82,6 @@ const renderAvatar = (
       {fallbackText}
     </div>
   );
-
-const getListingImage = (title: string, price: number) => {
-  const palette = [
-    ["#0f4c81", "#4f83ff"],
-    ["#c65d00", "#ffb347"],
-    ["#12664f", "#52b788"],
-    ["#5a189a", "#9d4edd"],
-  ];
-  const seed = title
-    .split("")
-    .reduce((total, character) => total + character.charCodeAt(0), 0);
-  const [startColor, endColor] = palette[seed % palette.length];
-  const initials = title
-    .split(" ")
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? "")
-    .join("") || "SS";
-  const safeTitle = title.slice(0, 28);
-
-  const svg = `
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400">
-      <defs>
-        <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
-          <stop offset="0%" stop-color="${startColor}" />
-          <stop offset="100%" stop-color="${endColor}" />
-        </linearGradient>
-      </defs>
-      <rect width="640" height="400" rx="36" fill="url(#g)" />
-      <circle cx="540" cy="86" r="86" fill="rgba(255,255,255,0.14)" />
-      <circle cx="126" cy="338" r="112" fill="rgba(255,255,255,0.1)" />
-      <text x="68" y="168" fill="white" font-family="Arial, sans-serif" font-size="88" font-weight="700">${initials}</text>
-      <text x="68" y="248" fill="rgba(255,255,255,0.92)" font-family="Arial, sans-serif" font-size="34" font-weight="600">${safeTitle}</text>
-      <text x="68" y="302" fill="rgba(255,255,255,0.78)" font-family="Arial, sans-serif" font-size="24">SwampSwap Listing</text>
-      <text x="68" y="352" fill="white" font-family="Arial, sans-serif" font-size="28" font-weight="700">$${price}</text>
-    </svg>
-  `;
-
-  return `data:image/svg+xml;charset=UTF-8,${encodeURIComponent(svg)}`;
-};
 
 function ListingsPage() {
   const navigate = useNavigate();
@@ -723,7 +684,7 @@ function ListingsPage() {
                       <CardContent className="space-y-3 pt-0">
                         <div className="overflow-hidden rounded-[1.5rem] border border-primary/10 bg-muted/50">
                           <img
-                            src={getListingImage(listing.title, listing.price)}
+                            src={getListingImageSrc(listing)}
                             alt={listing.title}
                             className="h-44 w-full object-cover transition duration-300 group-hover:scale-[1.02]"
                           />

--- a/frontend/src/pages/User/index.tsx
+++ b/frontend/src/pages/User/index.tsx
@@ -39,6 +39,7 @@ import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { getListingImageSrc } from "@/lib/listing-images";
 import { defaultProfileIcon, profileIconOptions } from "@/lib/profile-icons";
 import { listingCategories, listingConditions } from "@/types/listing";
 import type { CreateListingData, Listing } from "@/types/listing";
@@ -474,6 +475,13 @@ function UserPage() {
                       </div>
                     </CardHeader>
                     <CardContent className="space-y-3">
+                      <div className="overflow-hidden rounded-2xl border border-primary/10 bg-muted/50">
+                        <img
+                          src={getListingImageSrc(listing)}
+                          alt={listing.title}
+                          className="h-40 w-full object-cover"
+                        />
+                      </div>
                       <div className="flex flex-wrap gap-2">
                         <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
                           {listing.category}

--- a/frontend/src/types/listing.ts
+++ b/frontend/src/types/listing.ts
@@ -38,6 +38,8 @@ export interface Listing {
   condition: ListingCondition;
   user_id: number;
   status: ListingStatus;
+  image?: string | string[] | null;
+  imageUrls?: string[];
   seller_name?: string;
   seller_avatar?: string;
 }


### PR DESCRIPTION
Closes #67 

Added a new function in image.go called processMultipleImages() which can process multiple files at once which "POST /listings" and "PUT /listings/:id" now both support.
<b>However, since SQLite databases don't support list types, JSON Marshalling had to be used, so the frontend must use JSON Unmarshalling to get all of the file paths for the listings now, even if there is only 1 image, unlike before.</b>